### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/billford/horrorvibes/security/code-scanning/1](https://github.com/billford/horrorvibes/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only performs linting and does not require write access, we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to perform the workflow tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
